### PR TITLE
Made Start Menu Remember the Last Selected Button

### DIFF
--- a/world-of-wallhoppers/assets/scripts/Guis/start_screen.gd
+++ b/world-of-wallhoppers/assets/scripts/Guis/start_screen.gd
@@ -8,8 +8,20 @@ const RECORDS = preload("uid://bmm55s7158oio")
 @export var mutiplayer_button: Button
 @export var singleplayer_button: Button
 @export var quit_button: Button
+@export var records_button: Button
 @export var settings_button: Button
 @export var tutorial_button: Button
+
+@onready var buttons: Array[Button] = [
+	mutiplayer_button,
+	singleplayer_button,
+	quit_button,
+	records_button,
+	settings_button,
+	tutorial_button,
+]
+
+static var last_selected: int = 0
 
 ## Quit the game
 func quit() -> void:
@@ -18,21 +30,30 @@ func quit() -> void:
 	get_tree().quit()
 
 func _ready() -> void:
+	if last_selected >= 0 and last_selected < buttons.size():
+		buttons[last_selected].grab_focus()
 	# Prevents (some) crashes from weirdness with SceneSwitcher!
 	SceneSwitcher.last_scene = null
 
 func load_level_select(is_multiplayer: bool):
 	var level_select: Control = LEVEL_SELECT.instantiate()
 	level_select.is_multiplayer = is_multiplayer
-	get_tree().root.add_child(level_select)
-	queue_free()
+	unload_and_switch(level_select)
 
 func load_records() -> void:
 	var records: Control = RECORDS.instantiate()
-	get_tree().root.add_child(records)
-	queue_free()
+	unload_and_switch(records)
 
 func load_tutorial():
 	var tutorial: Node2D = TUTORIAL.instantiate()
-	get_tree().root.add_child(tutorial)
+	unload_and_switch(tutorial)
+
+func unload_and_switch(new_root: Node):
+	var index: int = -1
+	for i in range(buttons.size()):
+		if buttons[i] == get_viewport().gui_get_focus_owner():
+			index = i
+	last_selected = index
+	print(last_selected)
+	get_tree().root.add_child(new_root)
 	queue_free()

--- a/world-of-wallhoppers/project.godot
+++ b/world-of-wallhoppers/project.godot
@@ -25,7 +25,6 @@ LevelManager="*res://assets/scripts/LevelManager.gd"
 
 window/size/viewport_width=1080
 window/size/viewport_height=1920
-window/size/mode=4
 window/stretch/mode="viewport"
 
 [dotnet]

--- a/world-of-wallhoppers/scenes/start_screen.tscn
+++ b/world-of-wallhoppers/scenes/start_screen.tscn
@@ -111,8 +111,8 @@ scale_curve = SubResource("CurveTexture_1jj22")
 resource_name = "GrabFocus"
 script/source = "extends StartMenuButton
 
-func _ready() -> void:
-	grab_focus()
+#func _ready() -> void:
+	#grab_focus()
 "
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_bdg0b"]
@@ -294,7 +294,7 @@ font_size = 81
 outline_size = 38
 outline_color = Color(0, 0, 0, 1)
 
-[node name="StartScreen" type="Control" node_paths=PackedStringArray("mutiplayer_button", "singleplayer_button", "quit_button", "settings_button", "tutorial_button")]
+[node name="StartScreen" type="Control" node_paths=PackedStringArray("mutiplayer_button", "singleplayer_button", "quit_button", "records_button", "settings_button", "tutorial_button")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -305,6 +305,7 @@ script = ExtResource("1_kxo13")
 mutiplayer_button = NodePath("VBoxContainer/CenterContainer/PanelContainer/MarginContainer/VBoxContainer/Mutiplayer")
 singleplayer_button = NodePath("VBoxContainer/CenterContainer/PanelContainer/MarginContainer/VBoxContainer/SinglePlayer")
 quit_button = NodePath("VBoxContainer/CenterContainer/PanelContainer/MarginContainer/VBoxContainer/QuitButton")
+records_button = NodePath("VBoxContainer/CenterContainer/PanelContainer/MarginContainer/VBoxContainer/RecordsButton")
 settings_button = NodePath("VBoxContainer/CenterContainer/PanelContainer/MarginContainer/VBoxContainer/SettingsButton")
 tutorial_button = NodePath("VBoxContainer/CenterContainer/PanelContainer/MarginContainer/VBoxContainer/TutorialButton")
 


### PR DESCRIPTION
Made the Start Menu remember the last selected option, even when switching scenes, so when returning it returns back to the previously selected option.

This was just done using a static variable in the MenuStartScreen class, which always keeps track of the last button focused when switching to a different scene using the MenuStartScreen class's "unload_and_switch()" method, which is a condensed version of the duplicated code used previously