### PR TITLE
Made the Quit Buttons Send to Main Menu

### DIFF
--- a/world-of-wallhoppers/assets/scripts/win_scene.gd
+++ b/world-of-wallhoppers/assets/scripts/win_scene.gd
@@ -42,7 +42,9 @@ func _on_level_select_pressed() -> void:
 	queue_free()
 
 func _on_quit_pressed() -> void:
-	get_tree().quit(); 
+	get_tree().get_first_node_in_group("splitscreen").queue_free()
+	get_tree().change_scene_to_file("res://scenes/start_screen.tscn")
+	queue_free()
 
 func _on_name_input_pressed() -> void:
 	name_input_panel.show();

--- a/world-of-wallhoppers/scenes/gui/pause_menu.tscn
+++ b/world-of-wallhoppers/scenes/gui/pause_menu.tscn
@@ -46,7 +46,7 @@ text = "Resume"
 custom_minimum_size = Vector2(640, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 64
-text = "Quit"
+text = "Main Menu"
 
 [connection signal="pressed" from="CenterContainer/VBoxContainer/Resume" to="." method="_on_resume_pressed"]
 [connection signal="pressed" from="CenterContainer/VBoxContainer/Quit" to="." method="_on_quit_pressed"]

--- a/world-of-wallhoppers/scenes/win_scene.tscn
+++ b/world-of-wallhoppers/scenes/win_scene.tscn
@@ -69,7 +69,7 @@ text = "Level Select"
 [node name="Quit" type="Button" parent="VBoxContainer"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 100
-text = "Quit"
+text = "Main Menu"
 
 [node name="LeaderboardTitle" type="Label" parent="VBoxContainer"]
 custom_minimum_size = Vector2(0, 240)


### PR DESCRIPTION
The Pause Screen and Win Screen now send you to the Main Menu when pressing the Quit button. Also renamed the Quit buttons to "Main Menu", so it's more clear what they do. Of Note: The Pause screen didn't need code changes, as it already sends the player to the Main Menu. I just changed the button text to "Main Menu"