### PR TITLE
Modified Hitstun Physics

### DIFF
--- a/world-of-wallhoppers/assets/scripts/obstacles.gd
+++ b/world-of-wallhoppers/assets/scripts/obstacles.gd
@@ -1,20 +1,14 @@
 extends Node2D
+class_name Obstacle
 
-# When the player touches the obstacle
-func _on_area_2d_body_entered(body: Node2D) -> void:
-	if body is Player:
-		call_deferred("moveplayer", body)
+@export_enum("Facing Away", "Facing Angle") var launch_mode: int = 0
 
-# Handles knockback of the player 
-func moveplayer(body: Node2D):
-	if not body.hitstun:
-		body.hitstun = true
-		if not body.velocity.x == 0:
-			# Move the player in the opposite direction of their motion 
-			body.velocity.x = -(body.velocity.x/abs(body.velocity.x)) * 20*body.weight # 20 can be changed
-		if not body.velocity.y == 0:
-			body.velocity.y = -(body.velocity.y/abs(body.velocity.y)) * 20*body.weight
-		
-		# Create hitstun effect (time can be changed (currently 1 second))
-		await get_tree().create_timer(1).timeout
-		body.hitstun = false
+@export var direction_offset_angle: float = 0.0
+
+func get_direction(to_global_position: Vector2):
+	match launch_mode:
+		0:
+			return global_position.direction_to(to_global_position).rotated(deg_to_rad(direction_offset_angle))
+		1:
+			return Vector2.from_angle(global_rotation_degrees).rotated(direction_offset_angle)
+	return Vector2.ZERO

--- a/world-of-wallhoppers/scenes/obstacles/pufflip/pufflip.tscn
+++ b/world-of-wallhoppers/scenes/obstacles/pufflip/pufflip.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=9 format=3 uid="uid://40v37q8uw0gt"]
+[gd_scene load_steps=10 format=3 uid="uid://40v37q8uw0gt"]
 
 [ext_resource type="Script" uid="uid://b8eyq3cjx15vb" path="res://assets/scripts/objects/pufflip.gd" id="1_omwum"]
 [ext_resource type="Texture2D" uid="uid://b3qr8i6y54878" path="res://assets/sprites/pufflip/pufflip.png" id="1_tqlc6"]
+[ext_resource type="Script" uid="uid://cphusaq70x4jg" path="res://assets/scripts/obstacles.gd" id="3_vjo6s"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_omwum"]
 atlas = ExtResource("1_tqlc6")
@@ -48,12 +49,15 @@ animations = [{
 radius = 25.079872
 
 [node name="Pufflip" type="Node2D"]
+modulate = Color(0.417, 0.868, 0.737, 1)
 script = ExtResource("1_omwum")
 
 [node name="Sprite" type="AnimatedSprite2D" parent="."]
+rotation = 5.435406
 sprite_frames = SubResource("SpriteFrames_l0m2d")
-animation = &"Puff"
+animation = &"Shrink"
 autoplay = "Shrink"
+frame = 1
 
 [node name="FlipTimer" type="Timer" parent="."]
 autostart = true
@@ -61,6 +65,9 @@ autostart = true
 [node name="HitArea" type="Area2D" parent="."]
 collision_layer = 8
 collision_mask = 0
+script = ExtResource("3_vjo6s")
+launch_mode = 1
+direction_offset_angle = -90.0
 
 [node name="Collision" type="CollisionShape2D" parent="HitArea"]
 shape = SubResource("CircleShape2D_omwum")

--- a/world-of-wallhoppers/scenes/obstacles/spike.tscn
+++ b/world-of-wallhoppers/scenes/obstacles/spike.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=8 format=3 uid="uid://cl7i05js3l62q"]
+[gd_scene load_steps=9 format=3 uid="uid://cl7i05js3l62q"]
 
 [ext_resource type="Texture2D" uid="uid://3ekv2i16hkw0" path="res://assets/sprites/16-bit-spike-Sheet.png" id="1_ljd5v"]
+[ext_resource type="Script" uid="uid://cphusaq70x4jg" path="res://assets/scripts/obstacles.gd" id="2_n7p44"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_qcw7f"]
 atlas = ExtResource("1_ljd5v")
@@ -65,6 +66,9 @@ animation = &"spikeup"
 [node name="Area2D" type="Area2D" parent="."]
 collision_layer = 8
 collision_mask = 0
+script = ExtResource("2_n7p44")
+launch_mode = 1
+direction_offset_angle = -90.0
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Area2D"]
 position = Vector2(0.25, 0)


### PR DESCRIPTION
The player now is deflected "away" from the center of obstacles, and has reworked physics. Optionally, an "obstacles.gd" script can be added to the obstance, where the angle offset and launch type can be modified.
Launch Types:
Away: Launches player away from the direction of the object to the player
Angle: Lanches player at the angle of the obstacle