### PR TITLE
Fixed Hip's Flipping When Leaving Wall

### DIFF
--- a/world-of-wallhoppers/assets/scripts/characters/hip.gd
+++ b/world-of-wallhoppers/assets/scripts/characters/hip.gd
@@ -53,10 +53,7 @@ func update_flipped() -> void:
 		if left_wall: isFacingRight = false
 		if right_wall: isFacingRight = true
 	else:
-		if Input.is_action_just_pressed(move_left_action) and isFacingRight:
-			isFacingRight = false
-		elif Input.is_action_just_pressed(move_right_action) and not isFacingRight:
-			isFacingRight = true
+		super.update_flipped()
 
 func animate_hip(direction: float) -> void:
 	if hitstun:


### PR DESCRIPTION
- Hip now calls "super.update_flipped()" when not on wall, to ensure the script is synced with the player script
- Hip no longer moonwalks
Note: I was not able to make any other character moonwalk, it seems only hip needed to be fixed. Please tell me if I'm wrong though! 