### PR TITLE
singleplayer alignment fixed

### DIFF
--- a/world-of-wallhoppers/scenes/gui/character_select/character_select.tscn
+++ b/world-of-wallhoppers/scenes/gui/character_select/character_select.tscn
@@ -248,10 +248,6 @@ texture = ExtResource("6_o4o7f")
 stretch_mode = 2
 flip_h = true
 
-[node name="Control" type="Control" parent="MainVertical/Container/HorizontalPlayers"]
-custom_minimum_size = Vector2(16, 0)
-layout_mode = 2
-
 [node name="Player2" type="VBoxContainer" parent="MainVertical/Container/HorizontalPlayers"]
 layout_mode = 2
 size_flags_horizontal = 3


### PR DESCRIPTION
Removed an empty control node to ensure the character portrait box on singleplayer aligned with the center properly.
Fixes issue #163 