### PR TITLE
Updated Godot to 4.7.2

### DIFF
--- a/world-of-wallhoppers/project.godot
+++ b/world-of-wallhoppers/project.godot
@@ -8,11 +8,15 @@
 
 config_version=5
 
+[animation]
+
+compatibility/default_parent_skeleton_in_mesh_instance_3d=true
+
 [application]
 
 config/name="World of Wallhoppers"
 run/main_scene="uid://b2wwcwwsq0ao7"
-config/features=PackedStringArray("4.5", "Mobile")
+config/features=PackedStringArray("4.7", "Mobile")
 config/icon="res://icon.svg"
 
 [autoload]


### PR DESCRIPTION
- Tested World of Wallhoppers in Godot 4.7.2, found to problems
- Updated Project to Godot 4.7.2